### PR TITLE
Revert relative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [flexboxes](../../)
+# flexboxes
 <b>flexboxes</b> is a functional flexbox utility library and pure flexbox grid system. It offers a hybrid between other frameworks. It is designed for both prototyping and production.
 
 ## setup


### PR DESCRIPTION
Reverts ryanve/flexboxes#4

The relative link doesn't resolve the same way from Github pages.