### PR TITLE
Wrap based on orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,24 @@ npm install flexboxes
 - `.basis-auto`
 
 ### `@media`
+
+#### portrait
+
 - `.portrait-flex`
 - `.portrait-flex-item`
 - `.portrait-inline-flex`
+- `.portrait-flex-wrap`
+- `.portrait-flex-nowrap`
+- `.portrait-flex-wrap-reverse`
+
+#### landscape
+
 - `.landscape-flex`
 - `.landscape-flex-item`
 - `.landscape-inline-flex`
+- `.landscape-flex-wrap`
+- `.landscape-flex-nowrap`
+- `.landscape-flex-wrap-reverse`
 
 ## development
 

--- a/main.css
+++ b/main.css
@@ -120,10 +120,16 @@
   .portrait-flex { display: -webkit-box; display: -ms-flexbox; display: flex }
   .portrait-flex-item { display: flex-item }
   .portrait-inline-flex { display: -webkit-inline-box; display: -ms-inline-flexbox; display: inline-flex }
+  .portrait-flex-wrap { -ms-flex-wrap: wrap; flex-wrap: wrap }
+  .portrait-flex-nowrap { -ms-flex-wrap: nowrap; flex-wrap: nowrap }
+  .portrait-flex-wrap-reverse { -ms-flex-wrap: wrap-reverse; flex-wrap: wrap-reverse }
 }
 
 @media (orientation: landscape) {
   .landscape-flex { display: -webkit-box; display: -ms-flexbox; display: flex }
   .landscape-flex-item { display: flex-item }
   .landscape-inline-flex { display: -webkit-inline-box; display: -ms-inline-flexbox; display: inline-flex }
+  .landscape-flex-wrap { -ms-flex-wrap: wrap; flex-wrap: wrap }
+  .landscape-flex-nowrap { -ms-flex-wrap: nowrap; flex-wrap: nowrap }
+  .landscape-flex-wrap-reverse { -ms-flex-wrap: wrap-reverse; flex-wrap: wrap-reverse }
 }

--- a/module.css
+++ b/module.css
@@ -120,10 +120,16 @@
   .portrait-flex { display: flex }
   .portrait-flex-item { display: flex-item }
   .portrait-inline-flex { display: inline-flex }
+  .portrait-flex-wrap { flex-wrap: wrap }
+  .portrait-flex-nowrap { flex-wrap: nowrap }
+  .portrait-flex-wrap-reverse { flex-wrap: wrap-reverse }
 }
 
 @media (orientation: landscape) {
   .landscape-flex { display: flex }
   .landscape-flex-item { display: flex-item }
   .landscape-inline-flex { display: inline-flex }
+  .landscape-flex-wrap { flex-wrap: wrap }
+  .landscape-flex-nowrap { flex-wrap: nowrap }
+  .landscape-flex-wrap-reverse { flex-wrap: wrap-reverse }
 }


### PR DESCRIPTION
This add media query orientation classes for wrapping so support [responsive use cases like this](https://codepen.io/ryanve/pen/GmadWv)

```html
<div class="flex portrait-flex-wrap">
  <div class="flex-auto basis-6">1</div>
  <div class="flex-auto basis-6">2</div>
  <div class="flex-auto basis-6">3</div>
  <div class="flex-auto basis-6">4</div>
</div>
```

This only wraps in portrait orientation.