### PR TITLE
Revise setup documentation to include unpkg link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 
 ## setup
 
-```
-npm install flexboxes
-```
+- For <b>prototyping</b> or codepen you can get any version from [https://unpkg.com/flexboxes](https://unpkg.com/flexboxes)
+- For <b>production</b> you can [`npm install flexboxes`](https://www.npmjs.com/package/flexboxes) and import into your CSS bundle. 
 
 ```css
 @import 'node_modules/flexboxes/main';


### PR DESCRIPTION
## setup

- For <b>prototyping</b> or codepen you can get any version from [https://unpkg.com/flexboxes](https://unpkg.com/flexboxes)
- For <b>production</b> you can [`npm install flexboxes`](https://www.npmjs.com/package/flexboxes) and import into your CSS bundle. 

```css
@import 'node_modules/flexboxes/main';
```