### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto


### PR DESCRIPTION
Line endings seem fine being handled by [.editorconfig](https://github.com/ryanve/flexboxes/blob/master/.editorconfig)