### PR TITLE
Rename flex class

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 ## classes
 
 ### [`display`](https://www.w3.org/TR/css-flexbox-1/#flex-containers)
-- `.flex`
-- `.inline-flex`
+- `.block-flex` for `flex`
+- `.inline-flex` for `inline-flex`
 
 ### [`flex-direction`](https://www.w3.org/TR/css-flexbox-1/#flex-direction-property)
 - `.flex-row`

--- a/deprecated.css
+++ b/deprecated.css
@@ -1,0 +1,1 @@
+.flex { display: flex }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -1,4 +1,4 @@
-.flex { display: flex }
+.block-flex { display: flex }
 .inline-flex { display: inline-flex }
 
 .flex-row { flex-direction: row }


### PR DESCRIPTION
Rename `.flex` to `.block-flex` to avoid conflict in other frameworks and ease finding. CSS `display` is comprised of outside and inside values. `block flex` is the [full display value](https://drafts.csswg.org/css-display/#display-value-summary)