### PR TITLE
Rename flow classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,23 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 - `.block-flex` for `flex`
 - `.inline-flex` for `inline-flex`
 
+### [`flex-flow`](https://www.w3.org/TR/css-flexbox-1/#flex-flow-property)
+
+- Compose [`flex-direction`](#flex-direction) [`flex-wrap`](#flex-wrap)
+- Default is `row nowrap`
+
 ### [`flex-direction`](https://www.w3.org/TR/css-flexbox-1/#flex-direction-property)
-- `.flex-row`
-- `.flex-row-reverse`
-- `.flex-column`
-- `.flex-column-reverse`
+
+- `.flow-east` for `row`
+- `.flow-west` for `row-reverse`
+- `.flow-south` for `column`
+- `.flow-north` for `column-reverse`
 
 ### [`flex-wrap`](https://www.w3.org/TR/css-flexbox-1/#flex-wrap-property)
-- `.flex-wrap`
-- `.flex-nowrap`
-- `.flex-wrap-reverse`
+
+- `.flow-over` for `nowrap`
+- `.flow-wrap` for `wrap`
+- `.flow-warp` for `wrap-reverse`
 
 ### [distribute free space](https://www.w3.org/TR/css-flexbox-1/#auto-margins)
 - `.free-top`
@@ -154,17 +161,17 @@ These are breakpoint classes for responsive design.
 
 - `block-flex@portrait`
 - `inline-flex@portrait`
-- `flex-wrap@portrait`
-- `flex-nowrap@portrait`
-- `flex-wrap-reverse@portrait`
+- `flow-over@portrait`
+- `flow-wrap@portrait`
+- `flex-warp@portrait`
 
 #### `landscape` orientation only
 
 - `block-flex@landscape`
 - `inline-flex@landscape`
-- `flex-wrap@landscape`
-- `flex-nowrap@landscape`
-- `flex-wrap-reverse@landscape`
+- `flow-over@landscape`
+- `flow-wrap@landscape`
+- `flex-warp@landscape`
 
 ## examples
 
@@ -193,7 +200,7 @@ These are breakpoint classes for responsive design.
 ### [responsive wrapping](https://codepen.io/ryanve/pen/YVbLjQ)
 
 ```html
-<div class="flex flex-wrap@portrait">
+<div class="flex flow-wrap@portrait">
   <div class="flex-auto basis-6">1</div>
   <div class="flex-auto basis-6">2</div>
   <div class="flex-auto basis-6">3</div>

--- a/deprecated.css
+++ b/deprecated.css
@@ -1,9 +1,22 @@
 .flex { display: flex }
+.flex-row { flex-direction: row }
+.flex-row-reverse { flex-direction: row-reverse }
+.flex-column { flex-direction: column }
+.flex-column-reverse { flex-direction: column-reverse }
+.flex-wrap { flex-wrap: wrap }
+.flex-nowrap { flex-wrap: nowrap }
+.flex-wrap-reverse { flex-wrap: wrap-reverse }
 
 @media (orientation: portrait) {
   .flex\@portrait { display: flex }
+  .flex-wrap\@portrait { flex-wrap: wrap }
+  .flex-nowrap\@portrait { flex-wrap: nowrap }
+  .flex-wrap-reverse\@portrait { flex-wrap: wrap-reverse }
 }
 
 @media (orientation: landscape) {
   .flex\@landscape { display: flex }
+  .flex-wrap\@landscape { flex-wrap: wrap }
+  .flex-nowrap\@landscape { flex-wrap: nowrap }
+  .flex-wrap-reverse\@landscape { flex-wrap: wrap-reverse }
 }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -1,14 +1,13 @@
 .block-flex { display: flex }
 .inline-flex { display: inline-flex }
 
-.flex-row { flex-direction: row }
-.flex-row-reverse { flex-direction: row-reverse }
-.flex-column { flex-direction: column }
-.flex-column-reverse { flex-direction: column-reverse }
-
-.flex-wrap { flex-wrap: wrap }
-.flex-nowrap { flex-wrap: nowrap }
-.flex-wrap-reverse { flex-wrap: wrap-reverse }
+.flow-east { flex-direction: row }
+.flow-west { flex-direction: row-reverse }
+.flow-south { flex-direction: column }
+.flow-north { flex-direction: column-reverse }
+.flow-over { flex-wrap: nowrap }
+.flow-wrap { flex-wrap: wrap }
+.flow-warp { flex-wrap: wrap-reverse }
 
 .free-top { margin-top: auto }
 .free-left { margin-left: auto }
@@ -118,15 +117,15 @@
 @media (orientation: portrait) {
   .block-flex\@portrait { display: flex }
   .inline-flex\@portrait { display: inline-flex }
-  .flex-wrap\@portrait { flex-wrap: wrap }
-  .flex-nowrap\@portrait { flex-wrap: nowrap }
-  .flex-wrap-reverse\@portrait { flex-wrap: wrap-reverse }
+  .flow-over\@portrait { flex-wrap: nowrap }
+  .flow-wrap\@portrait { flex-wrap: wrap }
+  .flex-warp\@portrait { flex-wrap: wrap-reverse }
 }
 
 @media (orientation: landscape) {
   .block-flex\@landscape { display: flex }
   .inline-flex\@landscape { display: inline-flex }
-  .flex-wrap\@landscape { flex-wrap: wrap }
-  .flex-nowrap\@landscape { flex-wrap: nowrap }
-  .flex-wrap-reverse\@landscape { flex-wrap: wrap-reverse }
+  .flow-over\@landscape { flex-wrap: nowrap }
+  .flow-wrap\@landscape { flex-wrap: wrap }
+  .flex-warp\@landscape { flex-wrap: wrap-reverse }
 }


### PR DESCRIPTION
### deprecated

- `.flex-row`
- `.flex-row-reverse`
- `.flex-column`
- `.flex-column-reverse`
- `.flex-wrap`
- `.flex-nowrap`
- `.flex-wrap-reverse`

### new

- `.flow-east`
- `.flow-west`
- `.flow-south`
- `.flow-north`
- `.flow-over`
- `.flow-wrap`
- `.flow-warp`

### reasoning

- `flex-flow` is shorthand for `flex-directon` `flex-wrap`
- `flow-` seems easy to comprehend for all
- short names that avoid dashes are simpler
- default `nowrap` now precedes `wrap` in cascade
- i like `over` to indicate `nowrap` because it flows over and maybe overflows
- i like `warp` for `wrap-reverse` because when you use it you warp the wrap
- `over` `wrap` `warp` reinforce how `flex-wrap` behaves
- `east` `west` `south` `north` direction naming is memorable
- `east` `west` `south` `north` is reusable model for naming dependent on axes or mode

