### PR TITLE
Reduce flex shorthands

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,26 +80,18 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 - `.flex-min` re: [nesting](https://goo.gl/3IZRMt)
 - `.flex-max`
 
-### [`flex`](https://www.w3.org/TR/css-flexbox-1/#flex-property) presets
-- `.flex-golden`
-- `.flex-initial`
-- `.flex-auto`
-- `.flex-none`
+### [`flex`](https://www.w3.org/TR/css-flexbox-1/#flex-property)
 
-### [`flex`](https://www.w3.org/TR/css-flexbox-1/#flex-common) shorthand
-- `.flex-0`
-- `.flex-1`
-- `.flex-2`
-- `.flex-3`
-- `.flex-4`
-- `.flex-5`
-- `.flex-6`
-- `.flex-7`
-- `.flex-8`
-- `.flex-9`
-- `.flex-10`
-- `.flex-11`
-- `.flex-12`
+<a name="flex-presets"></a>
+<a name="flex-shorthand"></a>
+
+Shorthand classes supply [common presets](https://www.w3.org/TR/css-flexbox-1/#flex-common)
+
+- `.flex-initial` for `0 1 auto` aka shrinkable
+- `.flex-auto` for `1 1 auto` aka flexible
+- `.flex-none` for `none` aka inflexible
+
+Compose with [`grow`](#flex-grow) [`shrink`](#flex-shrink) [`basis`](#flex-basis)
 
 ### [`flex-grow`](https://www.w3.org/TR/css-flexbox-1/#flex-grow-property)
 - `.grow-0`

--- a/deprecated.css
+++ b/deprecated.css
@@ -7,6 +7,20 @@
 .flex-nowrap { flex-wrap: nowrap }
 .flex-wrap-reverse { flex-wrap: wrap-reverse }
 
+.flex-golden { flex: 0 1 61.803398875% }
+.flex-1 { flex: 1 }
+.flex-2 { flex: 2 }
+.flex-3 { flex: 3 }
+.flex-4 { flex: 4 }
+.flex-5 { flex: 5 }
+.flex-6 { flex: 6 }
+.flex-7 { flex: 7 }
+.flex-8 { flex: 8 }
+.flex-9 { flex: 9 }
+.flex-10 { flex: 10 }
+.flex-11 { flex: 11 }
+.flex-12 { flex: 12 }
+
 @media (orientation: portrait) {
   .flex\@portrait { display: flex }
   .flex-wrap\@portrait { flex-wrap: wrap }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -44,24 +44,9 @@
 
 .flex-min { min-height: 0; min-width: 0 }
 .flex-max { max-height: 100%; max-width: 100% }
-
-.flex-golden { flex: 0 1 61.803398875% }
 .flex-initial { flex: 0 1 auto }
 .flex-auto { flex: 1 1 auto }
 .flex-none { flex: 0 0 auto }
-
-.flex-1 { flex: 1 }
-.flex-2 { flex: 2 }
-.flex-3 { flex: 3 }
-.flex-4 { flex: 4 }
-.flex-5 { flex: 5 }
-.flex-6 { flex: 6 }
-.flex-7 { flex: 7 }
-.flex-8 { flex: 8 }
-.flex-9 { flex: 9 }
-.flex-10 { flex: 10 }
-.flex-11 { flex: 11 }
-.flex-12 { flex: 12 }
 
 .grow-0 { flex-grow: 0 }
 .grow-1 { flex-grow: 1 }


### PR DESCRIPTION
Remove [numeric flex shorthands](https://www.w3.org/TR/css-flexbox-1/#flex-common) `flex-1` thru `flex-12` and `flex-golden` because the shorthand seems confusing and these are composable via `grow` `shrink` `basis` classes. `flex-2` equates to `grow-2 shrink-1 basis-0` and imo `basis-auto` is preferred anyway.`flex-golden` equates to `flex-initial basis-golden`