### PR TITLE
Rename area classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 - `.content-around`
 - `.content-stretch`
 
-### size control
-- `.flex-min` re: [nesting](https://goo.gl/3IZRMt)
-- `.flex-max`
-
 ### [`flex`](https://www.w3.org/TR/css-flexbox-1/#flex-property)
 
 <a name="flex-presets"></a>
@@ -144,6 +140,16 @@ Compose with [`grow`](#flex-grow) [`shrink`](#flex-shrink) [`basis`](#flex-basis
 - `.basis-golden`
 - `.basis-content`
 - `.basis-auto`
+
+### area
+<a name="size-control"></a>
+
+Some [flexbugs](https://github.com/philipwalton/flexbugs) are solvable via min or max width or height
+
+- `.area-min` sets both mins to `0` [re: nesting](https://goo.gl/3IZRMt)
+- `.area-max` sets both maxes to `100%`
+
+Consider [area.css](https://github.com/ryanve/area.css) for more
 
 ### `@media`
 

--- a/deprecated.css
+++ b/deprecated.css
@@ -7,6 +7,8 @@
 .flex-nowrap { flex-wrap: nowrap }
 .flex-wrap-reverse { flex-wrap: wrap-reverse }
 
+.flex-min { min-height: 0; min-width: 0 }
+.flex-max { max-height: 100%; max-width: 100% }
 .flex-golden { flex: 0 1 61.803398875% }
 .flex-1 { flex: 1 }
 .flex-2 { flex: 2 }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -42,8 +42,9 @@
 .content-around { align-content: space-around }
 .content-stretch { align-content: stretch }
 
-.flex-min { min-height: 0; min-width: 0 }
-.flex-max { max-height: 100%; max-width: 100% }
+.area-min { min-height: 0; min-width: 0 }
+.area-max { max-height: 100%; max-width: 100% }
+
 .flex-initial { flex: 0 1 auto }
 .flex-auto { flex: 1 1 auto }
 .flex-none { flex: 0 0 auto }


### PR DESCRIPTION
Improve documentation about them too.

I wanna avoid overloading the term flex.

~`.flex-min`~  `.area-min`

~`.flex-max`~ `.area-max`