### PR TITLE
Shorten justify to just

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 - `.self-end`
 
 ### [`justify-content`](https://www.w3.org/TR/css-flexbox-1/#justify-content-property)
-- `.justify-start`
-- `.justify-end`
-- `.justify-center`
-- `.justify-between`
-- `.justify-around`
+- `.just-start`
+- `.just-end`
+- `.just-center`
+- `.just-between`
+- `.just-around`
 
 ### [`align-content`](https://www.w3.org/TR/css-flexbox-1/#align-content-property)
 - `.content-start`

--- a/deprecated.css
+++ b/deprecated.css
@@ -23,6 +23,12 @@
 .flex-11 { flex: 11 }
 .flex-12 { flex: 12 }
 
+.justify-start { justify-content: flex-start }
+.justify-end { justify-content: flex-end }
+.justify-center { justify-content: center }
+.justify-between { justify-content: space-between }
+.justify-around { justify-content: space-around }
+
 @media (orientation: portrait) {
   .flex\@portrait { display: flex }
   .flex-wrap\@portrait { flex-wrap: wrap }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -29,11 +29,11 @@
 .self-start { align-self: flex-start }
 .self-end { align-self: flex-end }
 
-.justify-start { justify-content: flex-start }
-.justify-end { justify-content: flex-end }
-.justify-center { justify-content: center }
-.justify-between { justify-content: space-between }
-.justify-around { justify-content: space-around }
+.just-start { justify-content: flex-start }
+.just-end { justify-content: flex-end }
+.just-center { justify-content: center }
+.just-between { justify-content: space-between }
+.just-around { justify-content: space-around }
 
 .content-start { align-content: flex-start }
 .content-end { align-content: flex-end }

--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
 
 <figure id="pushing">
   <figcaption><a href="#pushing">pushing</a></figcaption>
-  <demo-case class="block-flex justify-end">
+  <demo-case class="block-flex just-end">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -237,7 +237,7 @@
 
 <figure id="cushioning">
   <figcaption><a href="#cushioning">cushioning</a></figcaption>
-  <demo-case class="block-flex justify-around">
+  <demo-case class="block-flex just-around">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -246,7 +246,7 @@
 
 <figure id="tweening">
   <figcaption><a href="#tweening">tweening</a></figcaption>
-  <demo-case class="block-flex justify-between">
+  <demo-case class="block-flex just-between">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -255,7 +255,7 @@
 
 <figure id="racking">
   <figcaption><a href="#racking">racking</a></figcaption>
-  <demo-case class="block-flex justify-between flow-south">
+  <demo-case class="block-flex just-between flow-south">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -300,7 +300,7 @@
 
 <figure id="vining">
   <figcaption><a href="#vining">vining</a></figcaption>
-  <demo-case class="block-flex flow-east justify-center">
+  <demo-case class="block-flex flow-east just-center">
     <demo-item class="block-flex flow-south">
       <demo-item class="flex-auto">1</demo-item>
       <demo-item class="flex-auto">22</demo-item>
@@ -311,14 +311,14 @@
 
 <figure id="centering">
   <figcaption><a href="#centering">centering</a></figcaption>
-  <demo-case class="block-flex justify-center items-center">
+  <demo-case class="block-flex just-center items-center">
     <demo-item class="basis-4">1</demo-item>
   </demo-case>
 </figure>
 
 <figure id="winging">
   <figcaption><a href="#winging">winging</a></figcaption>
-  <demo-case class="block-flex justify-center items-center">
+  <demo-case class="block-flex just-center items-center">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-4">2</demo-item>
     <demo-item class="basis-2">3</demo-item>


### PR DESCRIPTION
Rename `justify-` classes to `just-` because I often misspell `justify` and I like the `just` vibe