### PR TITLE
Rename content classes to pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 - `.just-around`
 
 ### [`align-content`](https://www.w3.org/TR/css-flexbox-1/#align-content-property)
-- `.content-start`
-- `.content-end`
-- `.content-center`
-- `.content-between`
-- `.content-around`
-- `.content-stretch`
+- `.pack-start`
+- `.pack-end`
+- `.pack-center`
+- `.pack-between`
+- `.pack-around`
+- `.pack-stretch`
 
 ### [`flex`](https://www.w3.org/TR/css-flexbox-1/#flex-property)
 

--- a/deprecated.css
+++ b/deprecated.css
@@ -29,6 +29,13 @@
 .justify-between { justify-content: space-between }
 .justify-around { justify-content: space-around }
 
+.content-start { align-content: flex-start }
+.content-end { align-content: flex-end }
+.content-center { align-content: center }
+.content-between { align-content: space-between }
+.content-around { align-content: space-around }
+.content-stretch { align-content: stretch }
+
 @media (orientation: portrait) {
   .flex\@portrait { display: flex }
   .flex-wrap\@portrait { flex-wrap: wrap }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -35,12 +35,12 @@
 .just-between { justify-content: space-between }
 .just-around { justify-content: space-around }
 
-.content-start { align-content: flex-start }
-.content-end { align-content: flex-end }
-.content-center { align-content: center }
-.content-between { align-content: space-between }
-.content-around { align-content: space-around }
-.content-stretch { align-content: stretch }
+.pack-start { align-content: flex-start }
+.pack-end { align-content: flex-end }
+.pack-center { align-content: center }
+.pack-between { align-content: space-between }
+.pack-around { align-content: space-around }
+.pack-stretch { align-content: stretch }
 
 .area-min { min-height: 0; min-width: 0 }
 .area-max { max-height: 100%; max-width: 100% }


### PR DESCRIPTION
Content is such an overloaded term and often confuses me. I like pack for naming these because it helps remind me that it applies to how content packs together and that [`align-content`](https://drafts.csswg.org/css-align-3/#distribution-flex) in flexbox only applies to multiline flex containers.