### PR TITLE
Honor hidden

### DIFF
--- a/flexboxes.css
+++ b/flexboxes.css
@@ -115,3 +115,6 @@
   .flow-wrap\@landscape { flex-wrap: wrap }
   .flow-warp\@landscape { flex-wrap: wrap-reverse }
 }
+
+/* git.io/honorhidden */
+[hidden] { display: none }


### PR DESCRIPTION
Honour [`[hidden]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) behavior. Otherwise [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display) classes could unhide hidden elements. I considered using [`:not([hidden])`](https://developer.mozilla.org/en-US/docs/Web/CSS/:not) on each display class but that'd require more rules and more specificity. Putting this one rule down below restores `[hidden]` to `display: none` regardless of whether our other display classes are active. This approach seems unobtrusive because we restore the default. All libraries should respect hidden imo