### PR TITLE
Cascade auto before content basis

### DIFF
--- a/flexboxes.css
+++ b/flexboxes.css
@@ -97,8 +97,8 @@
 .basis-100vmin { flex-basis: 100vmin }
 
 .basis-golden { flex-basis: 61.803398875% }
-.basis-content { flex-basis: content }
 .basis-auto { flex-basis: auto }
+.basis-content { flex-basis: content }
 
 @media (orientation: portrait) {
   .block-flex\@portrait { display: flex }


### PR DESCRIPTION
[MDN mentions](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis) that `flex-basis` value `content` can be simulated by using `auto` together with a main size of `auto` where main size is `width` or `height` depending on main axis. Ordering our `auto` class before the `content` class supports this fallback approach because now both classes could be applied and `content` would fallback to `auto`