### PR TITLE
Logical freedom

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,14 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 
 <a name="distribute-free-space" href="https://ryanve.github.io/flexboxes#freeing">Distribute free space</a> via `auto` margins
 
-- `.free-top`
-- `.free-left`
-- `.free-right`
-- `.free-bottom`
+- `.free-top` frees top
+- `.free-left` frees left
+- `.free-right` frees right
+- `.free-bottom` frees bottom
+- `.free-north` frees block-start
+- `.free-south` frees block-end
+- `.free-west` frees inline-start
+- `.free-east` frees inline-end
 
 ### [`order`](https://www.w3.org/TR/css-flexbox-1/#order-property)
 - `.order-before`

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 <a name="distribute-free-space" href="https://ryanve.github.io/flexboxes#freeing">Distribute free space</a> via `auto` margins
 
 - `.free-top` frees top
+- `.free-bottom` frees bottom
 - `.free-left` frees left
 - `.free-right` frees right
-- `.free-bottom` frees bottom
 - `.free-north` frees block-start
 - `.free-south` frees block-end
 - `.free-west` frees inline-start

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -13,6 +13,10 @@
 .free-left { margin-left: auto }
 .free-right { margin-right: auto }
 .free-bottom { margin-bottom: auto }
+.free-east { margin-inline-end: auto }
+.free-west { margin-inline-start: auto }
+.free-south { margin-block-end: auto }
+.free-north { margin-block-start: auto }
 
 .order-before { order: -1 }
 .order-after { order: 1 }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -10,13 +10,13 @@
 .flow-warp { flex-wrap: wrap-reverse }
 
 .free-top { margin-top: auto }
+.free-bottom { margin-bottom: auto }
 .free-left { margin-left: auto }
 .free-right { margin-right: auto }
-.free-bottom { margin-bottom: auto }
-.free-east { margin-inline-end: auto }
-.free-west { margin-inline-start: auto }
-.free-south { margin-block-end: auto }
 .free-north { margin-block-start: auto }
+.free-south { margin-block-end: auto }
+.free-west { margin-inline-start: auto }
+.free-east { margin-inline-end: auto }
 
 .order-before { order: -1 }
 .order-after { order: 1 }


### PR DESCRIPTION
Provide free classes for freeing flex items based on logical margins. I put them after the physical margins to afford using physical margins as fallback. Naming east west south north uses the same model as our [directional classes](https://github.com/ryanve/flexboxes/tree/v0.9.0#flex-direction)