### PR TITLE
Use violet og:image

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#bae4ea">
 <meta name="description" content="Learn patterns from flexbox examples.">
+<meta property="og:image" content="https://user-images.githubusercontent.com/949985/82156190-d745d780-9847-11ea-9e78-ae29d8741cac.png">
+<meta property="og:image:alt" content="violet">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="1280">
 <link rel="stylesheet" href="deprecated.css" media="not all">
 <link rel="stylesheet" href="flexboxes.css">
 <link rel="icon" href="icon.svg">


### PR DESCRIPTION
uses [violet png](https://user-images.githubusercontent.com/949985/82156190-d745d780-9847-11ea-9e78-ae29d8741cac.png) from #54

```html
<meta property="og:image" content="https://user-images.githubusercontent.com/949985/82156190-d745d780-9847-11ea-9e78-ae29d8741cac.png">
<meta property="og:image:alt" content="violet">
<meta property="og:image:width" content="1280">
<meta property="og:image:height" content="1280">
```

omits [`og:image:type`](https://stackoverflow.com/q/61856825/770127)