### PR TITLE
Normalize contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   html {
     font: 20px/1.5 sans-serif;
     background: seashell;
-    color: #030303;
+    color: #0a0b0c;
   }
   body {
     margin: 0 auto;
@@ -45,6 +45,7 @@
     max-width: 30em;
   }
   demo-item {
+    color: #010101;
     display: block;
     box-sizing: border-box;
   }


### PR DESCRIPTION
Lessen contrast range.

Bring contrasts a lil closer to each other. 

- Reduce text contrast from [19.19](https://contrast-ratio.com/#%23030303-on-seashell) to [18.33](https://contrast-ratio.com/#%230a0b0c-on-seashell)
- Raise violet contrast from [8.9](https://contrast-ratio.com/#%23030303-on-violet) to [9](https://contrast-ratio.com/#%23010101-on-violet)
- Raise gold contrast from [14.7](https://contrast-ratio.com/#%23030303-on-gold) to [14.88](https://contrast-ratio.com/#%23010101-on-gold)