### PR TITLE
Rename initial to fade

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 
 Shorthand classes supply [common presets](https://www.w3.org/TR/css-flexbox-1/#flex-common)
 
-- `.flex-initial` for `0 1 auto` aka shrinkable
+- `.flex-fade` for `0 1 auto` aka shrinkable
 - `.flex-auto` for `1 1 auto` aka flexible
 - `.flex-none` for `none` aka inflexible
 

--- a/deprecated.css
+++ b/deprecated.css
@@ -10,6 +10,7 @@
 .flex-min { min-height: 0; min-width: 0 }
 .flex-max { max-height: 100%; max-width: 100% }
 .flex-golden { flex: 0 1 61.803398875% }
+.flex-initial { flex: 0 1 auto }
 .flex-1 { flex: 1 }
 .flex-2 { flex: 2 }
 .flex-3 { flex: 3 }

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -50,7 +50,7 @@
 .area-min { min-height: 0; min-width: 0 }
 .area-max { max-height: 100%; max-width: 100% }
 
-.flex-initial { flex: 0 1 auto }
+.flex-fade { flex: 0 1 auto }
 .flex-auto { flex: 1 1 auto }
 .flex-none { flex: 0 0 auto }
 


### PR DESCRIPTION
I'm favoring names that abstract what the classes do. Alternative names I considered for this were `init` `slim` `calm` `less` but `fade` seems nicest imo