### PR TITLE
Cascade inline before block

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 ## classes
 
 ### [`display`](https://www.w3.org/TR/css-flexbox-1/#flex-containers)
-- `.block-flex` for `flex`
 - `.inline-flex` for `inline-flex`
+- `.block-flex` for `flex`
 
 ### [`flex-flow`](https://www.w3.org/TR/css-flexbox-1/#flex-flow-property)
 
@@ -171,8 +171,6 @@ class="block-flex flow-west@portrait flow-north@landscape"
 
 #### `portrait`
 
-- `block-flex@portrait`
-- `inline-flex@portrait`
 - `flow-east@portrait`
 - `flow-west@portrait`
 - `flow-south@portrait`
@@ -180,11 +178,11 @@ class="block-flex flow-west@portrait flow-north@landscape"
 - `flow-over@portrait`
 - `flow-wrap@portrait`
 - `flow-warp@portrait`
+- `inline-flex@portrait`
+- `block-flex@portrait`
 
 #### `landscape`
 
-- `block-flex@landscape`
-- `inline-flex@landscape`
 - `flow-east@landscape`
 - `flow-west@landscape`
 - `flow-south@landscape`
@@ -192,6 +190,8 @@ class="block-flex flow-west@portrait flow-north@landscape"
 - `flow-over@landscape`
 - `flow-wrap@landscape`
 - `flow-warp@landscape`
+- `inline-flex@landscape`
+- `block-flex@landscape`
 
 ## examples
 

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -6,8 +6,6 @@ npm.im/flexboxes
 .flex-fame {flex: 1 0 auto}
 .flex-auto {flex: 1 1 auto}
 .flex-none {flex: 0 0 auto}
-.block-flex {display: flex}
-.inline-flex {display: inline-flex}
 .flow-east {flex-direction: row}
 .flow-west {flex-direction: row-reverse}
 .flow-south {flex-direction: column}
@@ -15,6 +13,8 @@ npm.im/flexboxes
 .flow-over {flex-wrap: nowrap}
 .flow-wrap {flex-wrap: wrap}
 .flow-warp {flex-wrap: wrap-reverse}
+.inline-flex {display: inline-flex}
+.block-flex {display: flex}
 
 .free-all {margin: auto}
 .free-top {margin-top: auto}
@@ -107,8 +107,6 @@ npm.im/flexboxes
 .basis-content {flex-basis: content}
 
 @media (orientation: portrait) {
-  .block-flex\@portrait {display: flex}
-  .inline-flex\@portrait {display: inline-flex}
   .flow-east\@portrait {flex-direction: row}
   .flow-west\@portrait {flex-direction: row-reverse}
   .flow-south\@portrait {flex-direction: column}
@@ -116,11 +114,11 @@ npm.im/flexboxes
   .flow-over\@portrait {flex-wrap: nowrap}
   .flow-wrap\@portrait {flex-wrap: wrap}
   .flow-warp\@portrait {flex-wrap: wrap-reverse}
+  .inline-flex\@portrait {display: inline-flex}
+  .block-flex\@portrait {display: flex}
 }
 
 @media (orientation: landscape) {
-  .block-flex\@landscape {display: flex}
-  .inline-flex\@landscape {display: inline-flex}
   .flow-east\@landscape {flex-direction: row}
   .flow-west\@landscape {flex-direction: row-reverse}
   .flow-south\@landscape {flex-direction: column}
@@ -128,6 +126,8 @@ npm.im/flexboxes
   .flow-over\@landscape {flex-wrap: nowrap}
   .flow-wrap\@landscape {flex-wrap: wrap}
   .flow-warp\@landscape {flex-wrap: wrap-reverse}
+  .inline-flex\@landscape {display: inline-flex}
+  .block-flex\@landscape {display: flex}
 }
 
 /* git.io/honorhidden */


### PR DESCRIPTION
I tend to [sequence](https://github.com/ryanve/flow.css/blob/master/display.css) inline classes before block ones to give block displays higher priority