### PR TITLE
Rename display classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Download [flexboxes.css](flexboxes.css) and load [stylesheet](https://dev.opera.
 ## classes
 
 ### [`display`](https://www.w3.org/TR/css-flexbox-1/#flex-containers)
-- `.inline-flex` for `inline-flex`
-- `.block-flex` for `flex`
+- `.flex-inline` for `inline-flex`
+- `.flex-block` for `flex`
 
 ### [`flex-flow`](https://www.w3.org/TR/css-flexbox-1/#flex-flow-property)
 
@@ -166,7 +166,7 @@ Consider [area.css](https://github.com/ryanve/area.css) for more
 Responsive [`orientation`](https://drafts.csswg.org/mediaqueries-4/#orientation) classes are available for [`flex-flow`](#flex-flow) and [`display`](#display) classes. Append [`@portrait`](#portrait) or [`@landscape`](#landscape) to these classes to limit them to that orientation. This affords layouts that flow or wrap differently based on viewport orientation or layouts that only flex in one orientation. Try the [#fitting](https://ryanve.github.io/flexboxes/#fitting) example in both portrait and landscape to see how it adapts. You can do this on a phone by rotating the phone or on a computer by resizing the browser window.
 
 ```html
-class="block-flex flow-west@portrait flow-north@landscape"
+class="flex-block flow-west@portrait flow-north@landscape"
 ```
 
 #### `portrait`
@@ -178,8 +178,8 @@ class="block-flex flow-west@portrait flow-north@landscape"
 - `flow-over@portrait`
 - `flow-wrap@portrait`
 - `flow-warp@portrait`
-- `inline-flex@portrait`
-- `block-flex@portrait`
+- `flex-inline@portrait`
+- `flex-block@portrait`
 
 #### `landscape`
 
@@ -190,8 +190,8 @@ class="block-flex flow-west@portrait flow-north@landscape"
 - `flow-over@landscape`
 - `flow-wrap@landscape`
 - `flow-warp@landscape`
-- `inline-flex@landscape`
-- `block-flex@landscape`
+- `flex-inline@landscape`
+- `flex-block@landscape`
 
 ## examples
 

--- a/deprecated.css
+++ b/deprecated.css
@@ -1,4 +1,6 @@
 .flex {display: flex}
+.inline-flex {display: inline-flex}
+.block-flex {display: flex}
 .flex-row {flex-direction: row}
 .flex-row-reverse {flex-direction: row-reverse}
 .flex-column {flex-direction: column}
@@ -39,6 +41,8 @@
 
 @media (orientation: portrait) {
   .flex\@portrait {display: flex}
+  .inline-flex\@portrait {display: inline-flex}
+  .block-flex\@portrait {display: flex}
   .flex-wrap\@portrait {flex-wrap: wrap}
   .flex-nowrap\@portrait {flex-wrap: nowrap}
   .flex-wrap-reverse\@portrait {flex-wrap: wrap-reverse}
@@ -46,6 +50,8 @@
 
 @media (orientation: landscape) {
   .flex\@landscape {display: flex}
+  .inline-flex\@landscape {display: inline-flex}
+  .block-flex\@landscape {display: flex}
   .flex-wrap\@landscape {flex-wrap: wrap}
   .flex-nowrap\@landscape {flex-wrap: nowrap}
   .flex-wrap-reverse\@landscape {flex-wrap: wrap-reverse}

--- a/flexboxes.css
+++ b/flexboxes.css
@@ -6,6 +6,8 @@ npm.im/flexboxes
 .flex-fame {flex: 1 0 auto}
 .flex-auto {flex: 1 1 auto}
 .flex-none {flex: 0 0 auto}
+.flex-inline {display: inline-flex}
+.flex-block {display: flex}
 .flow-east {flex-direction: row}
 .flow-west {flex-direction: row-reverse}
 .flow-south {flex-direction: column}
@@ -13,8 +15,6 @@ npm.im/flexboxes
 .flow-over {flex-wrap: nowrap}
 .flow-wrap {flex-wrap: wrap}
 .flow-warp {flex-wrap: wrap-reverse}
-.inline-flex {display: inline-flex}
-.block-flex {display: flex}
 
 .free-all {margin: auto}
 .free-top {margin-top: auto}
@@ -107,6 +107,8 @@ npm.im/flexboxes
 .basis-content {flex-basis: content}
 
 @media (orientation: portrait) {
+  .flex-inline\@portrait {display: inline-flex}
+  .flex-block\@portrait {display: flex}
   .flow-east\@portrait {flex-direction: row}
   .flow-west\@portrait {flex-direction: row-reverse}
   .flow-south\@portrait {flex-direction: column}
@@ -114,11 +116,11 @@ npm.im/flexboxes
   .flow-over\@portrait {flex-wrap: nowrap}
   .flow-wrap\@portrait {flex-wrap: wrap}
   .flow-warp\@portrait {flex-wrap: wrap-reverse}
-  .inline-flex\@portrait {display: inline-flex}
-  .block-flex\@portrait {display: flex}
 }
 
 @media (orientation: landscape) {
+  .flex-inline\@landscape {display: inline-flex}
+  .flex-block\@landscape {display: flex}
   .flow-east\@landscape {flex-direction: row}
   .flow-west\@landscape {flex-direction: row-reverse}
   .flow-south\@landscape {flex-direction: column}
@@ -126,8 +128,6 @@ npm.im/flexboxes
   .flow-over\@landscape {flex-wrap: nowrap}
   .flow-wrap\@landscape {flex-wrap: wrap}
   .flow-warp\@landscape {flex-wrap: wrap-reverse}
-  .inline-flex\@landscape {display: inline-flex}
-  .block-flex\@landscape {display: flex}
 }
 
 /* git.io/honorhidden */

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 
 <figure id="shelving">
   <figcaption><a href="#shelving">shelving</a></figcaption>
-  <demo-case class="block-flex">
+  <demo-case class="flex-block">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -73,7 +73,7 @@
 
 <figure id="stacking">
   <figcaption><a href="#stacking">stacking</a></figcaption>
-  <demo-case class="block-flex flow-south">
+  <demo-case class="flex-block flow-south">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -82,7 +82,7 @@
 
 <figure id="flipping">
   <figcaption><a href="#flipping">flipping</a></figcaption>
-  <demo-case class="block-flex flow-west">
+  <demo-case class="flex-block flow-west">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -91,7 +91,7 @@
 
 <figure id="flopping">
   <figcaption><a href="#flopping">flopping</a></figcaption>
-  <demo-case class="block-flex flow-north">
+  <demo-case class="flex-block flow-north">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -100,7 +100,7 @@
 
 <figure id="ordering">
   <figcaption><a href="#ordering">ordering</a></figcaption>
-  <demo-case class="block-flex flow-south">
+  <demo-case class="flex-block flow-south">
     <demo-item class="flex-auto order-before">1</demo-item>
     <demo-item class="flex-auto order-after">2</demo-item>
     <demo-item class="flex-auto order-before">3</demo-item>
@@ -109,7 +109,7 @@
 
 <figure id="wrapping">
   <figcaption><a href="#wrapping">wrapping</a></figcaption>
-  <demo-case class="block-flex flow-wrap">
+  <demo-case class="flex-block flow-wrap">
     <demo-item class="basis-4">1</demo-item>
     <demo-item class="basis-4">2</demo-item>
     <demo-item class="basis-4">3</demo-item>
@@ -123,7 +123,7 @@
 
 <figure id="warping">
   <figcaption><a href="#warping">warping</a></figcaption>
-  <demo-case class="block-flex flow-warp">
+  <demo-case class="flex-block flow-warp">
     <demo-item class="basis-4">1</demo-item>
     <demo-item class="basis-4">2</demo-item>
     <demo-item class="basis-4">3</demo-item>
@@ -137,7 +137,7 @@
 
 <figure id="fitting">
   <figcaption><a href="#fitting">fitting</a></figcaption>
-  <demo-case class="block-flex flow-wrap@portrait">
+  <demo-case class="flex-block flow-wrap@portrait">
     <demo-item class="basis-6">1</demo-item>
     <demo-item class="basis-6">2</demo-item>
     <demo-item class="basis-6">3</demo-item>
@@ -151,7 +151,7 @@
 
 <figure id="growing">
   <figcaption><a href="#growing">growing</a></figcaption>
-  <demo-case class="block-flex">
+  <demo-case class="flex-block">
     <demo-item class="grow-1">1</demo-item>
     <demo-item class="grow-2">2</demo-item>
     <demo-item class="grow-3">3</demo-item>
@@ -160,7 +160,7 @@
 
 <figure id="shrinking">
   <figcaption><a href="#shrinking">shrinking</a></figcaption>
-  <demo-case class="block-flex">
+  <demo-case class="flex-block">
     <demo-item class="shrink-1">1</demo-item>
     <demo-item class="shrink-2">2</demo-item>
     <demo-item class="shrink-3">3</demo-item>
@@ -169,7 +169,7 @@
 
 <figure id="basing">
   <figcaption><a href="#basing">basing</a></figcaption>
-  <demo-case class="block-flex">
+  <demo-case class="flex-block">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -178,7 +178,7 @@
 
 <figure id="freeing">
   <figcaption><a href="#freeing">freeing</a></figcaption>
-  <demo-case class="block-flex">
+  <demo-case class="flex-block">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2 free-left">3</demo-item>
@@ -187,7 +187,7 @@
 
 <figure id="pushing">
   <figcaption><a href="#pushing">pushing</a></figcaption>
-  <demo-case class="block-flex just-end">
+  <demo-case class="flex-block just-end">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -196,7 +196,7 @@
 
 <figure id="cushioning">
   <figcaption><a href="#cushioning">cushioning</a></figcaption>
-  <demo-case class="block-flex just-around">
+  <demo-case class="flex-block just-around">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -205,7 +205,7 @@
 
 <figure id="tweening">
   <figcaption><a href="#tweening">tweening</a></figcaption>
-  <demo-case class="block-flex just-between">
+  <demo-case class="flex-block just-between">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -214,7 +214,7 @@
 
 <figure id="racking">
   <figcaption><a href="#racking">racking</a></figcaption>
-  <demo-case class="block-flex just-between flow-south">
+  <demo-case class="flex-block just-between flow-south">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -223,7 +223,7 @@
 
 <figure id="roofing">
   <figcaption><a href="#roofing">roofing</a></figcaption>
-  <demo-case class="block-flex flow-wrap items-start">
+  <demo-case class="flex-block flow-wrap items-start">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -232,7 +232,7 @@
 
 <figure id="flooring">
   <figcaption><a href="#flooring">flooring</a></figcaption>
-  <demo-case class="block-flex flow-wrap items-end">
+  <demo-case class="flex-block flow-wrap items-end">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -241,7 +241,7 @@
 
 <figure id="stretching">
   <figcaption><a href="#stretching">stretching</a></figcaption>
-  <demo-case class="block-flex flow-wrap items-stretch">
+  <demo-case class="flex-block flow-wrap items-stretch">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -250,7 +250,7 @@
 
 <figure id="belting">
   <figcaption><a href="#belting">belting</a></figcaption>
-  <demo-case class="block-flex flow-wrap items-center">
+  <demo-case class="flex-block flow-wrap items-center">
     <demo-item class="flex-auto">1</demo-item>
     <demo-item class="flex-auto">2</demo-item>
     <demo-item class="flex-auto">3</demo-item>
@@ -259,8 +259,8 @@
 
 <figure id="vining">
   <figcaption><a href="#vining">vining</a></figcaption>
-  <demo-case class="block-flex flow-east just-center">
-    <demo-item class="block-flex flow-south">
+  <demo-case class="flex-block flow-east just-center">
+    <demo-item class="flex-block flow-south">
       <demo-item class="flex-auto">1</demo-item>
       <demo-item class="flex-auto">22</demo-item>
       <demo-item class="flex-auto">333</demo-item>
@@ -270,14 +270,14 @@
 
 <figure id="centering">
   <figcaption><a href="#centering">centering</a></figcaption>
-  <demo-case class="block-flex just-center items-center">
+  <demo-case class="flex-block just-center items-center">
     <demo-item class="basis-4">1</demo-item>
   </demo-case>
 </figure>
 
 <figure id="winging">
   <figcaption><a href="#winging">winging</a></figcaption>
-  <demo-case class="block-flex just-center items-center">
+  <demo-case class="flex-block just-center items-center">
     <demo-item class="basis-2">1</demo-item>
     <demo-item class="basis-4">2</demo-item>
     <demo-item class="basis-2">3</demo-item>
@@ -286,7 +286,7 @@
 
 <figure id="shelling">
   <figcaption><a href="#shelling">shelling</a></figcaption>
-  <demo-case class="block-flex flow-wrap">
+  <demo-case class="flex-block flow-wrap">
     <demo-item class="basis-1">1</demo-item>
     <demo-item class="basis-2">2</demo-item>
     <demo-item class="basis-3">3</demo-item>
@@ -297,9 +297,9 @@
 
 <figure id="squiding">
   <figcaption><a href="#squiding">squiding</a></figcaption>
-  <demo-case class="block-flex flow-wrap flow-west">
+  <demo-case class="flex-block flow-wrap flow-west">
     <demo-item class="flex-auto basis-4">0</demo-item>
-    <demo-item class="flex-auto basis-8 block-flex flow-south">
+    <demo-item class="flex-auto basis-8 flex-block flow-south">
       <demo-item class="flex-auto">1</demo-item>
       <demo-item class="flex-auto">2</demo-item>
       <demo-item class="flex-auto">3</demo-item>


### PR DESCRIPTION
Start `display` classes with `flex` as further abstraction

FYI i plan to add the other way to lower level library [flow.css](https://github.com/ryanve/flow.css)